### PR TITLE
Intern strings stored in ASMDataTable

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/discovery/ASMDataTable.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ASMDataTable.java
@@ -38,9 +38,21 @@ public class ASMDataTable {
 
         public ASMData(ModCandidate candidate, String annotationName, String className, String objectName, Map<String, Object> info) {
             this.candidate = candidate;
-            this.annotationName = annotationName;
-            this.className = className;
-            this.objectName = objectName;
+            if (annotationName != null) {
+                this.annotationName = annotationName.intern();
+            } else {
+                this.annotationName = null;
+            }
+            if (className != null) {
+                this.className = className.intern();
+            } else {
+                this.className = null;
+            }
+            if (objectName != null) {
+                this.objectName = objectName.intern();
+            } else {
+                this.objectName = null;
+            }
             this.annotationInfo = info;
         }
 


### PR DESCRIPTION
Strings such as "org.jetbrains.annotations.NotNull" gets duplicated over 10k times, which for that one annotation is 1MB. I estimate with a medium amount of Skyblock mods this will save at least 5MB of heap.